### PR TITLE
Add TypeScript Declaration File

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'riteway' {
   export function describe(label: string, callback: describeCallback): void
   
-  export function Try(fn: Function, ...args: Array<any>): any
+  export function Try<U, V>(fn: (...args: U) => V, ...args: U): any
 
   type describeCallback = (should: should) => Promise<void>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'riteway' {
   export function describe(label: string, callback: describeCallback): void
   
-  export function Try(fn: Function, ...args: Array<number>): any
+  export function Try(fn: Function, ...args: Array<any>): any
 
   type describeCallback = (should: should) => Promise<void>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
 declare module 'riteway' {
   export function describe(label: string, callback: describeCallback): void
+  
+  export function Try(fn: Function, ...args: Array<number>): any
 
   type describeCallback = (should: should) => Promise<void>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,16 @@
+declare module 'riteway' {
+  export function describe(label: string, callback: describeCallback): void
+
+  type describeCallback = (should: should) => Promise<void>
+
+  type should = (label?: string) => { assert: assert }
+
+  type assert = (assertion: Assertion) => void
+
+  interface Assertion {
+    given: string
+    should: string
+    actual: any
+    expected: any
+  }
+}


### PR DESCRIPTION
Tested in https://github.com/poetapp/node by deleting the current riteway.d.ts file.

`npm run test:unit` started failing with the following error:

```
$ npm run test:unit

> @po.et/node@1.0.3 test:unit .../Projects/poet/node
> ts-node -r tsconfig-paths/register -r reflect-metadata --files ./tests/unit/index.ts


.../Projects/poet/node/node_modules/ts-node/src/index.ts:261
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
src/API/Middlewares/RequestValidationMiddleware.test.ts(2,26): error TS7016: Could not find a declaration file for module 'riteway'. '.../Projects/poet/node/node_modules/riteway/source/index.js' implicitly has an 'any' type.
  Try `npm install @types/riteway` if it exists or add a new declaration (.d.ts) file containing `declare module 'riteway';`

    at ...
```

I then locally cloned the riteway repo and tested it:

```
git clone git@github.com:lautarodragan/riteway
cd riteway/
git checkout patch-1
npm i -g
cd ../poet/node
npm link riteway
npm run test:unit
```

Now the tests are passing again.