### PR TITLE
drop should param in callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ const sum = (...args) => {
   return args.reduce((acc, n) => acc + n, 0);
 };
 
-describe('sum()', async should => {
-  const { assert } = should('return the correct sum');
+describe('sum()', async ({ assert }) => {
+  const should = 'return the correct sum';
 
   assert({
     given: 'no arguments',
@@ -30,12 +30,14 @@ describe('sum()', async should => {
 
   assert({
     given: 'zero',
+    should,
     actual: sum(2, 0),
     expected: 2
   });
 
   assert({
     given: 'negative numbers',
+    should,
     actual: sum(1, -4),
     expected: -3
   });

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,16 +3,14 @@ declare module 'riteway' {
   
   export function Try<U extends any[], V>(fn: (...args: U) => V, ...args: U): any
 
-  type describeCallback = (should: should) => Promise<void>
-
-  type should = (label?: string) => { assert: assert }
+  type describeCallback = ({ assert: assert }) => Promise<void>
 
   type assert = (assertion: Assertion) => void
 
   interface Assertion {
-    given: string
-    should?: string
-    actual: any
-    expected: any
+    readonly given: string
+    readonly should: string
+    readonly actual: any
+    readonly expected: any
   }
 }

--- a/source/riteway.js
+++ b/source/riteway.js
@@ -4,20 +4,19 @@ const tape = require('tape');
 const describe = (unit, cb) => tape(unit, assert => {
   const end = assert.end.bind(assert);
 
-  const result = cb(description => ({
-    assert: ({ actual, expected, given, should = description }) =>
-      assert.same(
-        actual, expected,
-        `Given ${ given }: should ${ should }`
-      ),
-    // We can probably use async/await to deal with most async tests,
-    // but we should probably still supply `end()` so users can do
-    // whatever they like
-    end
-  }));
+  const result = cb({
+    assert: riteAssert(assert),
+    end,
+  });
 
   if (result && result.then) result.then(end);
 });
+
+const riteAssert = (tapeAssert) => ({ actual, expected, given, should }) =>
+  tapeAssert.same(
+    actual, expected,
+    `Given ${ given }: should ${ should }`
+  );
 
 const Try = (fn, ...args) => {
   try {

--- a/source/test.js
+++ b/source/test.js
@@ -6,8 +6,8 @@ const sum = (...args) => {
   return args.reduce((acc, n) => acc + n, 0);
 };
 
-describe('sum()', async should => {
-  const { assert } = should('return the correct sum');
+describe('sum()', async ({ assert, end }) => {
+  const should = 'return the correct sum'
 
   assert({
     given: 'no arguments',
@@ -18,12 +18,14 @@ describe('sum()', async should => {
 
   assert({
     given: 'zero',
+    should,
     actual: sum(2, 0),
     expected: 2
   });
 
   assert({
     given: 'negative numbers',
+    should,
     actual: sum(1, -4),
     expected: -3
   });


### PR DESCRIPTION
## Description

This PR introduces a change to how RITEway is used.

Instead of the current

```js
describe('sum()', async should => {
  const { assert } = should('return the correct sum');

  assert({
    given: 'no arguments',
    should: 'return 0',
    actual: sum(),
    expected: 0
  });
```

a new, simpler way is introduced:

```js
describe('sum()', async ({ assert, end }) => {
  assert({
    given: 'no arguments',
    should: 'return 0',
    actual: sum(),
    expected: 0
  });
```

## Background

I believe the possibility of passing a default value for `should` goes against the goal of RITEway: it makes the tests less readable by moving one of the four elements of the assertion outside the assertion block, all the way up to the top of the `describe` block.

It also introduces an awkward step that winds up being copy-pasted all over.

## Default Should

If desired, a sort-of-default `should` value can succinctly be achieved using the shorthand syntax.

```js
  const should = 'return the correct sum';
  assert({
    given: 'zero',
    should,
    actual: sum(2, 0),
    expected: 2
  });
```

## Breaking

This is a breaking change. A new major version will be needed, and tests using RITEway will need a slight code change to adapt to the new version.

## WIP

This is still a WIP. Still need to test it in an actual project, both plain JS and TS.

