### PR TITLE
Adjust Try to be async

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'riteway' {
   export function describe(label: string, TestFunction: TestFunction): void
 
-  export function Try<U extends any[], V>(fn: (...args: U) => V, ...args: U): any
+  export function Try<U extends any[], V>(fn: (...args: U) => V, ...args: U): Promise<any>
 
   export function createStream(opts: CreateStreamOptions): ReadableStream
 

--- a/source/riteway.js
+++ b/source/riteway.js
@@ -24,9 +24,9 @@ const describe = (unit = '', TestFunction = noop) => tape(unit, test => {
   if (result && result.then) return result.then(end);
 });
 
-const Try = (fn = noop, ...args) => {
+const Try = async (fn = noop, ...args) => {
   try {
-    return fn(...args);
+    return await fn(...args);
   } catch (err) {
     return err;
   }

--- a/source/test.js
+++ b/source/test.js
@@ -33,7 +33,7 @@ describe('sum()', async assert => {
   assert({
     given: 'NaN',
     should: 'throw',
-    actual: Try(sum, 1, NaN),
+    actual: await Try(sum, 1, NaN),
     expected: new TypeError('NaN')
   });
 });

--- a/source/test.js
+++ b/source/test.js
@@ -46,3 +46,15 @@ describe('createStream()', async assert => {
     expected: 'function'
   });
 });
+
+describe('Try()', async assert => {
+  {
+    const error = new Error('ooops');
+    assert({
+      given: 'an async function that throws',
+      should: 'await and return the value of the error',
+      actual: (await Try(async () => { throw error; }, 'irrelivant')).toString(),
+      expected: error.toString()
+    });
+  }
+});


### PR DESCRIPTION
Breaking change. 

Adjusting try to be async makes it more useful for testing async functions.