### PR TITLE
feat: add .skip() and .only()

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ describe = (unit: String, cb: TestFunction) => Void
 
 Describe takes a prose description of the unit under test (function, module, whatever), and a callback function (`cb: TestFunction`). The callback function should be an [async function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) so that the test can automatically complete when it reaches the end. RITEWay assumes that all tests are asynchronous. Async functions automatically return a promise in JavaScript, so RITEWay knows when to end each test.
 
+### describe.only
+
+```js
+describe.only = (unit: String, cb: TestFunction) => Void
+```
+
+Like Describe, but don't run any other tests in the test suite.  See [test.only](https://github.com/substack/tape#testonlyname-cb)
+
+### describe.skip
+
+```js
+describe.skip = (unit: String, cb: TestFunction) => Void
+```
+
+Skip running this test. See [test.skip](https://github.com/substack/tape#testskipname-cb)
 
 ### TestFunction
 

--- a/source/riteway.js
+++ b/source/riteway.js
@@ -2,8 +2,7 @@ const tape = require('tape');
 
 const noop = new Function();
 
-// The testing library: a thin wrapper around tape
-const describe = (unit = '', TestFunction = noop) => tape(unit, test => {
+const withRiteway = TestFunction => test => {
   const end = () => test.end();
 
   const assert = ({
@@ -22,7 +21,14 @@ const describe = (unit = '', TestFunction = noop) => tape(unit, test => {
   const result = TestFunction(assert);
 
   if (result && result.then) return result.then(end).catch(end);
-});
+};
+
+const withTape = tapeFn => (unit = '', TestFunction = noop) => tapeFn(unit, withRiteway(TestFunction));
+
+// The testing library: a thin wrapper around tape
+const describe = withTape(tape);
+describe.only = withTape(tape.only);
+describe.skip = tape.skip;
 
 const Try = (fn = noop, ...args) => {
   try {

--- a/source/riteway.js
+++ b/source/riteway.js
@@ -20,7 +20,7 @@ const withRiteway = TestFunction => test => {
 
   const result = TestFunction(assert, end);
 
-  if (result && result.then) return result.then(end)
+  if (result && result.then) return result.then(end);
 };
 
 const withTape = tapeFn => (unit = '', TestFunction = noop) => tapeFn(unit, withRiteway(TestFunction));
@@ -29,7 +29,6 @@ const withTape = tapeFn => (unit = '', TestFunction = noop) => tapeFn(unit, with
 const describe = withTape(tape);
 describe.only = withTape(tape.only);
 describe.skip = tape.skip;
-
 
 const identity = x => x;
 const isPromise = x => x && typeof x.then === 'function';

--- a/source/test.js
+++ b/source/test.js
@@ -1,3 +1,4 @@
+const tape = require('tape');
 const { describe, Try, createStream } = require('./riteway');
 
 // a function to test
@@ -72,4 +73,33 @@ describe('Try()', async assert => {
       expected: error.toString()
     });
   }
+});
+
+describe('skip()', async assert => {
+  assert({
+    given: 'describe.skip',
+    should: 'be equal to tape.skip',
+    actual: describe.skip === tape.skip,
+    expected: true
+  });
+});
+
+describe('only()', async () => {
+  describe.only('a test marked as the only one to run', async assert => {
+    assert({
+      given: 'a test using only()',
+      should: 'run just this single test',
+      actual: true,
+      expected: true
+    });
+  });
+
+  describe('a non-executing test', async assert => {
+    assert({
+      given: 'another test only()',
+      should: 'not run this test',
+      actual: false,
+      expected: true
+    });
+  });
 });


### PR DESCRIPTION
This PR exposes tape's .only() and .skip() methods on riteway's describe().