### PR TITLE
Fix usage with bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.0.0",
   "description": "Unit tests that always supply a good bug report when they fail.",
   "main": "source/index.js",
+  "module": "source/riteway.js",
   "bin": {
     "riteway": "./bin/riteway"
   },


### PR DESCRIPTION
`module` field [must be present](https://github.com/standard-things/esm#bundling) in _package.json_ to make the package work with Parcel (and other bundlers).

Otherwise, running an example Parcel project does not succeed:

![image](https://user-images.githubusercontent.com/2717097/53298050-e6063000-3838-11e9-881a-21ed5e194e36.png)

Plus, a warning is issued twice upon building the example project:

![image](https://user-images.githubusercontent.com/2717097/53297865-db966700-3835-11e9-909d-888250c19007.png)

The same problem was recently discovered with Autodux: https://github.com/ericelliott/autodux/pull/50#issuecomment-466211028.