### PR TITLE
fix(typings): Add the missing describe export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ declare module 'riteway' {
 
   export function createStream(opts: CreateStreamOptions): ReadableStream
 
-  export function describe(description: string, assert: TestFunction): Promise<void>
+  export function describe(unit: string, testFunction: TestFunction): Promise<void>
 
   type assert = <T>(assertion: Assertion<T>) => void
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,8 @@ declare module 'riteway' {
 
   export function createStream(opts: CreateStreamOptions): ReadableStream
 
+  export function describe(description: string, assert: TestFunction): Promise<void>
+
   type assert = <T>(assertion: Assertion<T>) => void
 
   type TestFunction = (assert: assert, end?: Function) => Promise<void>


### PR DESCRIPTION
This PR fixes the missing export of the describe function in the index.d.ts