### PR TITLE
Upgrade 'esm' to version 3.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1341,9 +1341,9 @@
       "dev": true
     },
     "esm": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.6.tgz",
-      "integrity": "sha512-3wWjSurKSczMzYyHiBih3VVEQYCoZa6nfsqqcM2Tx6KBAQAeor0SZUfAol+zeVUtESLygayOi2ZcMfYZy7MCsg=="
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.7.tgz",
+      "integrity": "sha512-zsyD5gO8CY9dpK3IrdC4WHtvtHGXEFOpYA4zB+6p+Kygf3vv/6kF3YMEQLOArwKPPNvKt8gjI8UYhQW8bXM/YQ=="
     },
     "espree": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "cheerio": "1.0.0-rc.2",
-    "esm": "3.2.6",
+    "esm": "3.2.7",
     "react-dom": "16.8.3",
     "tape": "4.10.1"
   }


### PR DESCRIPTION
Upgrade `esm` dependency to version 3.2.7 in order to address failing [`autodux`](https://github.com/ericelliott/autodux) builds: https://github.com/ericelliott/autodux/pull/53 and https://github.com/ericelliott/autodux/pull/54.