### PR TITLE
Include the createComponent pattern in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,43 @@ I don't recommend unit testing stateful components, or components with side-effe
 
 A great alternative is to encapsulate side-effects and state management in container components, and then pass state into pure components as props. Unit test the pure components and use functional tests to ensure that the complete UX flow works in real browsers from the user's perspective.
 
+#### Isolating React Unit Tests
+
+When you [unit test React components](https://medium.com/javascript-scene/unit-testing-react-components-aeda9a44aae2) you frequently have to render your components many times. Sometimes the component needs to be wrapped in context (e.g. React Router or Redux) and often you want different props for some tests.
+
+RITEway makes it easy to isolate your tests while keeping them readable by using `create` functions in conjunction with [compound statements](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/block).
+
+```js
+import ClickCounter from '../click-counter/click-counter-component';
+
+describe('ClickCounter component', async assert => {
+  const createCounter = clickCount =>
+    render(<ClickCounter clicks={ clickCount } />)
+  ;
+  
+  {
+    const count = 3;
+    const $ = createCounter(count);
+    assert({
+      given: 'a click count',
+      should: 'render the correct number of clicks.',
+      actual: parseInt($('.clicks-count').html().trim(), 10),
+      expected: count
+    });
+  }
+  
+  {
+    const count = 5;
+    const $ = createCounter(count);
+    assert({
+      given: 'a click count',
+      should: 'render the correct number of clicks.',
+      actual: parseInt($('.clicks-count').html().trim(), 10),
+      expected: count
+    });
+  }
+});
+```
 
 ## Output
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ A great alternative is to encapsulate side-effects and state management in conta
 
 When you [unit test React components](https://medium.com/javascript-scene/unit-testing-react-components-aeda9a44aae2) you frequently have to render your components many times. Sometimes the component needs to be wrapped in context (e.g. React Router or Redux) and often you want different props for some tests.
 
-RITEway makes it easy to isolate your tests while keeping them readable by using `create` functions in conjunction with [compound statements](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/block).
+RITEway makes it easy to isolate your tests while keeping them readable by using [factory functions](https://link.medium.com/WxHPhCc3OV) in conjunction with [block scope](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/block).
 
 ```js
 import ClickCounter from '../click-counter/click-counter-component';


### PR DESCRIPTION
I thought it might be useful to teach first time users of RITEway the test isolation pattern that you used in your "Unit Testing React Components" article. I wrote a little explanation, took some code from the article and linked the article.