### PR TITLE
Add missing keys warning.

### DIFF
--- a/source/riteway.js
+++ b/source/riteway.js
@@ -2,17 +2,27 @@ import tape from 'tape';
 
 const noop = new Function();
 const isPromise = x => x && typeof x.then === 'function';
+const requiredKeys = ['given', 'should', 'actual', 'expected'];
+const concatToString = (keys, key, index) => keys + (index ? ', ' : '') + key;
 
 const withRiteway = TestFunction => test => {
   const end = () => test.end();
 
-  const assert = ({
-    // initialize values to undefined so TypeScript doesn't complain
-    given = undefined,
-    should = '',
-    actual = undefined,
-    expected = undefined
-  } = {}) => {
+  const assert = (args = {}) => {
+    const missing = requiredKeys.filter(
+      k => !Object.keys(args).includes(k)
+    );
+    if (missing.length) {
+      throw new Error(`Missing key(s): ${missing.reduce(concatToString, '')}`);
+    }
+    const {
+      // initialize values to undefined so TypeScript doesn't complain
+      given = undefined,
+      should = '',
+      actual = undefined,
+      expected = undefined
+    } = args;
+
     test.same(
       actual, expected,
       `Given ${given}: should ${should}`

--- a/source/riteway.js
+++ b/source/riteway.js
@@ -13,7 +13,7 @@ const withRiteway = TestFunction => test => {
       k => !Object.keys(args).includes(k)
     );
     if (missing.length) {
-      throw new Error(`Missing key(s): ${missing.reduce(concatToString, '')}`);
+      throw new Error(`The following parameters are required by \`assert\`: ${missing.reduce(concatToString, '')}`);
     }
 
     const {

--- a/source/riteway.js
+++ b/source/riteway.js
@@ -15,6 +15,7 @@ const withRiteway = TestFunction => test => {
     if (missing.length) {
       throw new Error(`Missing key(s): ${missing.reduce(concatToString, '')}`);
     }
+
     const {
       // initialize values to undefined so TypeScript doesn't complain
       given = undefined,

--- a/source/test.js
+++ b/source/test.js
@@ -93,7 +93,7 @@ describe('assert()', async assert => {
         given: 'calling `assert` with missing keys',
         should: 'throw with missing keys',
         actual: error.message,
-        expected: 'Missing key(s): given, should, actual, expected',
+        expected: 'The following parameters are required by `assert`: given, should, actual, expected',
       });
     }
   }
@@ -106,7 +106,7 @@ describe('assert()', async assert => {
         given: 'calling `assert` with missing keys',
         should: 'throw with missing keys',
         actual: error.message,
-        expected: 'Missing key(s): actual, expected',
+        expected: 'The following parameters are required by `assert`: actual, expected',
       });
     }
   }

--- a/source/test.js
+++ b/source/test.js
@@ -56,6 +56,7 @@ describe('describe()', (assert, end) => {
   }, 50);
 });
 
+
 describe('createStream()', async assert => {
   assert({
     given: 'typeof check',
@@ -77,6 +78,41 @@ describe('Try()', async assert => {
   }
 });
 
+describe('assert()', async assert => {
+  assert({
+    given: 'some key is undefined',
+    should: 'not throw',
+    actual: undefined,
+    expected: undefined
+  });
+
+  {
+    try {
+      assert({});
+    } catch (error) {
+      assert({
+        given: 'calling `assert` with missing keys',
+        should: 'throw with missing keys',
+        actual: error.message,
+        expected: 'Missing key(s): given, should, actual, expected',
+      });
+    }
+  }
+
+  {
+    try {
+      assert({ given: 'some keys', should: 'find the missing keys' });
+    } catch (error) {
+      assert({
+        given: 'calling `assert` with missing keys',
+        should: 'throw with missing keys',
+        actual: error.message,
+        expected: 'Missing key(s): actual, expected',
+      });
+    }
+  }
+});
+
 describe('skip()', async assert => {
   assert({
     given: 'describe.skip',
@@ -88,7 +124,7 @@ describe('skip()', async assert => {
 
 describe('renderComponent', async assert => {
   const text = 'Foo';
-  const $ = render(<div className="foo">{ text }</div>);
+  const $ = render(<div className="foo">{text}</div>);
 
   assert({
     given: 'A react component',
@@ -102,7 +138,7 @@ describe('countKeys()', async assert => {
   assert({
     given: 'an object',
     should: 'return the number of own props in the object',
-    actual: countKeys({a: 'a', b: 'b', c: 'c'}),
+    actual: countKeys({ a: 'a', b: 'b', c: 'c' }),
     expected: 3
   });
 });

--- a/source/test.js
+++ b/source/test.js
@@ -56,7 +56,6 @@ describe('describe()', (assert, end) => {
   }, 50);
 });
 
-
 describe('createStream()', async assert => {
   assert({
     given: 'typeof check',


### PR DESCRIPTION
`assert` throws now when the user forgets to add a key to its args.

*PS:* My editor messed up the brackets at two places and refuses to save the file otherwise 🤔 