### PR TITLE
fix: escape regex in match

### DIFF
--- a/source/match-test.js
+++ b/source/match-test.js
@@ -33,4 +33,21 @@ describe('match', async assert => {
       expected: '4 cats'
     });
   }
+
+  {
+    const given = 'some text that includes regex meta characters';
+    const should = 'return the matched text';
+
+    const textWithRegexMetaChar = '<h1>Are there any cats?</h1>';
+    const pattern = 'Are there any cats?';
+    const contains = match(textWithRegexMetaChar);
+
+    assert({
+      given,
+      should,
+      actual: contains(pattern),
+      expected: 'Are there any cats?'
+    });
+  }
+
 });

--- a/source/match.js
+++ b/source/match.js
@@ -1,17 +1,19 @@
-
 /**
  * Take some text to search and returns a function
  * which takes a pattern and returns the matched text,
- * if found, or an empty string. The pattern can be a 
+ * if found, or an empty string. The pattern can be a
  * string or regular expression.
- * 
+ *
  * @param {string} text The text to search.
  * @returns {(pattern: string|Object) => string}
  */
 const match = text => pattern => {
-  const RE = new RegExp(pattern);
+  const RE = new RegExp(typeof pattern === 'string' ? escapeRegex(pattern) : pattern);
   const matched = text.match(RE);
   return matched ? matched[0] : '';
 };
+
+const escapeRegex = string =>
+  string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 
 export default match;


### PR DESCRIPTION
When using `riteway/match`, and the pattern you try to match is a string that contains regex meta characters, `match` does not behave as expected. 

Example given;

```js
const text = '<h1>Are there any cats?</h1>';
const pattern = 'Are there any cats?';
const contains = match(pattern);

/*
operator: deepEqual
expected: |-
  'Are there any cats?'
actual: |-
  'Are there any cats'
*/
```
`match` will try and match against the pattern `Are there any cats` and has omitted the `?`, as it is interpreted as a regex meta character. 

The code change in this PR escapes any regex meta characters when the supplied pattern is of type `String`. Please see the added test that documents this behaviour.
