### PR TITLE
Fix types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ declare module 'riteway' {
 }
 
 declare module "riteway/render-component" {
-  export default function render(el: JSX.Element): CheerioStatic;
+  export default function render(el: JSX.Element): cheerio.Root;
 }
 
 declare module "riteway/match" {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "eslint source && echo 'Lint complete.'",
     "lint-fix": "eslint --fix source && eslint --fix ./*.js",
-    "typecheck": "npx -p typescript tsc --esModuleInterop --rootDir . source/test.js --allowJs --checkJs --noEmit --lib es6 --jsx react && echo 'TypeScript check complete.'",
+    "typecheck": "npx -p typescript tsc --esModuleInterop --rootDir . source/test.js --allowJs --checkJs --noEmit --lib es6 --jsx react && npx -p typescript tsc index.d.ts --noEmit && echo 'TypeScript check complete.'",
     "ts": "npm run -s typecheck",
     "test": "node -r @babel/register source/test",
     "watch": "watch 'clear && npm run -s test | tap-nirvana && npm run -s lint && npm run -s typecheck' source",


### PR DESCRIPTION
According to [this PR in DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46006) the types for cheerio have changed. To be precise, `CheerioStatic` was renamed to `Root` in namespace `cheerio`.

This PR changes the return type of `render` and adds an additional type check for `index.d.ts`.

When working on the package, I saw you use `npx -p typescript tsc`. Since you declared typescript a dev dependency, wouldn't it be possible to call `tsc` directly? 

Thanks for creating such a wonderful package.