### PR TITLE
feat(ai): support glob patterns in riteway ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,15 @@ riteway ai path/to/my-feature-test.sudo
 
 By default this runs **4 passes**, requires **75% pass rate**, uses the **claude** agent, runs up to **4 tests concurrently**, and allows **300 seconds** per agent call.
 
+You can pass multiple files or glob patterns. Files are executed sequentially (to respect API rate limits), and all files run even if one fails — you get a combined report at the end.
+
 ```shell
+# Run all .sudo files under prompts/
+riteway ai 'prompts/**/*.sudo'
+
+# Run multiple patterns
+riteway ai 'evals/**/*.sudo' 'tests/**/*.sudo'
+
 # Specify runs, threshold, and agent
 riteway ai path/to/test.sudo --runs 10 --threshold 80 --agent opencode
 

--- a/bin/riteway.js
+++ b/bin/riteway.js
@@ -84,7 +84,7 @@ const mainAIRunner = asyncPipe(
 const handleAIError = handleAIErrors({
   ValidationError: ({ message }) => {
     console.error(`❌ Validation failed: ${message}`);
-    console.error('\nUsage: riteway ai <file> [--runs N] [--threshold P] [--agent NAME | --agent-config FILE] [--color] [--save-responses]');
+    console.error('\nUsage: riteway ai <patterns...> [--runs N] [--threshold P] [--agent NAME | --agent-config FILE] [--color] [--save-responses]');
     console.error(`  --runs N               Number of test runs per assertion (default: ${defaults.runs})`);
     console.error(`  --threshold P          Required pass percentage 0-100 (default: ${defaults.threshold})`);
     console.error(`  --timeout MS           Per-agent-call timeout in milliseconds (default: ${defaults.timeoutMs})`);
@@ -178,7 +178,7 @@ const main = async (argv) => {
     console.log(`
 Usage:
   riteway <patterns...> [options]       Run test files
-  riteway ai <file> [options]           Run AI prompt evaluations
+  riteway ai <patterns...> [options]     Run AI prompt evaluations
   riteway ai init [--force]             Write agent config registry to ${registryFileName}
 
 Test Runner Options:
@@ -206,6 +206,7 @@ Authentication:
 
 Examples:
   riteway 'test/**/*.js'
+  riteway ai 'prompts/**/*.sudo' --runs 1 --threshold 75
   riteway ai prompts/test.sudo --runs 10 --threshold 80
   riteway ai prompts/test.sudo --agent cursor --runs 5
   riteway ai prompts/test.sudo --agent opencode --runs 5

--- a/source/ai-command.js
+++ b/source/ai-command.js
@@ -1,6 +1,7 @@
 import { basename } from 'path';
 import minimist from 'minimist';
 import { z } from 'zod';
+import { globSync } from 'glob';
 import { createError } from 'error-causes';
 import { ValidationError, AITestError, OutputError } from './ai-errors.js';
 import { resolveAgentConfig } from './agent-config.js';
@@ -11,7 +12,7 @@ import { defaults, runsSchema, thresholdSchema, concurrencySchema, timeoutSchema
 
 // agent accepts any string here — custom registry agents are resolved at run time
 const aiArgsSchema = z.object({
-  filePath: z.string({ error: 'Test file path is required' }),
+  patterns: z.array(z.string()).min(1, { error: 'At least one test file path or glob pattern is required' }),
   runs: runsSchema,
   threshold: thresholdSchema,
   timeout: timeoutSchema,
@@ -70,7 +71,7 @@ export const parseAIArgs = (argv) => {
   const agentConfigPath = opts['agent-config'] ? opts['agent-config'] : undefined;
 
   const parsed = {
-    filePath: opts._[0],
+    patterns: opts._.length > 0 ? opts._ : [],
     runs: Number(opts.runs),
     threshold: Number(opts.threshold),
     timeout: Number(opts.timeout),
@@ -118,124 +119,163 @@ export const formatAssertionReport = ({ passed, requirement, passCount, totalRun
 };
 
 /**
- * Orchestrate AI test execution: validate file path, verify agent auth, run tests,
- * record TAP output to ai-evals/, and report results to console.
- * Throws AITestError when the pass rate falls below threshold.
- *
- * TODO (follow-up): console.log calls are mixed with orchestration here. A future
- * refactor could return a structured result and let the CLI layer own all output,
- * aligning with the saga pattern's IO-separation principle. Not critical for this PR.
- *
+ * Resolve glob patterns to concrete file paths.
+ * @param {string[]} patterns - File paths or glob patterns
+ * @returns {string[]} Resolved file paths
+ */
+export const resolveAITestFiles = (patterns) => {
+  const files = patterns.flatMap(pattern => globSync(pattern));
+
+  if (files.length === 0) {
+    throw createError({
+      ...ValidationError,
+      message: `No test files found matching: ${patterns.join(', ')}`
+    });
+  }
+
+  return files;
+};
+
+/**
+ * Run a single AI test file: validate path, run tests, record output, report results.
  * @param {Object} options - Test run options
  * @returns {Promise<string>} Path to the recorded TAP output file
  */
-export const runAICommand = async ({ filePath, runs, threshold, timeout, agent, agentConfigPath, color, saveResponses, concurrency, cwd }) => {
-  if (!filePath) {
+const runSingleFile = async ({ filePath, runs, threshold, timeout, agentConfig, color, saveResponses, concurrency, cwd }) => {
+  const testFilename = basename(filePath);
+  const fullPath = validateFilePath(filePath, cwd);
+
+  console.log(`\nRunning AI tests: ${testFilename}`);
+
+  const results = await runAITests({
+    filePath: fullPath,
+    runs,
+    threshold,
+    timeout,
+    agentConfig,
+    concurrency
+  });
+
+  let outputPath;
+  try {
+    outputPath = await recordTestOutput({
+      results,
+      testFilename,
+      saveResponses
+    });
+  } catch (error) {
+    throw createError({
+      ...OutputError,
+      message: `Failed to record test output: ${error.message}`,
+      cause: error
+    });
+  }
+
+  const { assertions } = results;
+  const passedAssertions = assertions.filter(a => a.passed).length;
+  const totalAssertions = assertions.length;
+
+  console.log(`Results recorded: ${outputPath}`);
+  console.log(`Assertions: ${passedAssertions}/${totalAssertions} passed`);
+  console.log(assertions.map(a => formatAssertionReport({ ...a, color })).join('\n'));
+
+  if (!results.passed) {
+    const passRate = totalAssertions > 0 ? Math.round(passedAssertions / totalAssertions * 100) : 0;
+    throw createError({
+      ...AITestError,
+      message: `Test suite failed: ${passedAssertions}/${totalAssertions} assertions passed (${passRate}%)`,
+      passRate,
+      threshold
+    });
+  }
+
+  console.log('Test suite passed!');
+  return outputPath;
+};
+
+/**
+ * Orchestrate AI test execution: resolve file patterns, verify agent auth,
+ * run tests for each file, record TAP output to ai-evals/, and report results.
+ * Throws AITestError when the pass rate falls below threshold.
+ *
+ * @param {Object} options - Test run options
+ * @returns {Promise<string[]>} Paths to the recorded TAP output files
+ */
+export const runAICommand = async ({ patterns, runs, threshold, timeout, agent, agentConfigPath, color, saveResponses, concurrency, cwd }) => {
+  if (!patterns || patterns.length === 0) {
     throw createError({
       ...ValidationError,
       message: 'Test file path is required'
     });
   }
 
-  const testFilename = basename(filePath);
+  const filePaths = resolveAITestFiles(patterns);
 
-  try {
-    const fullPath = validateFilePath(filePath, cwd);
-    const agentConfig = await resolveAgentConfig({ agent, agentConfigPath, cwd });
+  const agentConfig = await resolveAgentConfig({ agent, agentConfigPath, cwd });
 
-    const agentLabel = agentConfigPath
-      ? `custom (${agentConfigPath})`
-      : agent;
+  const agentLabel = agentConfigPath
+    ? `custom (${agentConfigPath})`
+    : agent;
 
-    console.log(`Running AI tests: ${testFilename}`);
-    console.log(`Configuration: ${runs} runs, ${threshold}% threshold, ${concurrency} concurrent, ${timeout}ms timeout, agent: ${agentLabel}, responses: ${saveResponses ? 'saving' : 'off'}`);
+  console.log(`Configuration: ${runs} runs, ${threshold}% threshold, ${concurrency} concurrent, ${timeout}ms timeout, agent: ${agentLabel}, responses: ${saveResponses ? 'saving' : 'off'}`);
+  console.log(`Test files: ${filePaths.length}`);
 
-    console.log(`\nVerifying ${agentLabel} agent authentication...`);
-    const authResult = await verifyAgentAuthentication({
-      agentConfig,
-      timeout: 30000
+  console.log(`\nVerifying ${agentLabel} agent authentication...`);
+  const authResult = await verifyAgentAuthentication({
+    agentConfig,
+    timeout: 30000
+  });
+
+  if (!authResult.success) {
+    throw createError({
+      ...ValidationError,
+      message: `Agent authentication failed: ${authResult.error}`
     });
+  }
+  console.log('✓ Agent authenticated successfully');
 
-    if (!authResult.success) {
-      throw createError({
-        ...ValidationError,
-        message: `Agent authentication failed: ${authResult.error}`
-      });
-    }
-    console.log('✓ Agent authenticated successfully\n');
-
-    const results = await runAITests({
-      filePath: fullPath,
-      runs,
-      threshold,
-      timeout,
-      agentConfig,
-      concurrency
-    });
-
-    let outputPath;
+  // Run all files, collecting results and errors. Files that fail do not
+  // prevent the remaining files from running (run-all, report-all).
+  const outputPaths = [];
+  const errors = [];
+  for (const filePath of filePaths) {
     try {
-      outputPath = await recordTestOutput({
-        results,
-        testFilename,
-        saveResponses
+      const outputPath = await runSingleFile({
+        filePath, runs, threshold, timeout, agentConfig, color, saveResponses, concurrency, cwd
       });
+      outputPaths.push(outputPath);
     } catch (error) {
-      throw createError({
-        ...OutputError,
-        message: `Failed to record test output: ${error.message}`,
-        cause: error
-      });
-    }
-
-    const { assertions } = results;
-    const passedAssertions = assertions.filter(a => a.passed).length;
-    const totalAssertions = assertions.length;
-
-    console.log(`\nResults recorded: ${outputPath}`);
-    console.log(`Assertions: ${passedAssertions}/${totalAssertions} passed`);
-    console.log(assertions.map(a => formatAssertionReport({ ...a, color })).join('\n'));
-
-    if (!results.passed) {
-      const passRate = totalAssertions > 0 ? Math.round(passedAssertions / totalAssertions * 100) : 0;
-      throw createError({
-        ...AITestError,
-        message: `Test suite failed: ${passedAssertions}/${totalAssertions} assertions passed (${passRate}%)`,
-        passRate,
-        threshold
-      });
-    }
-
-    console.log('Test suite passed!');
-    return outputPath;
-  } catch (error) {
-    // If the error carries partial results (e.g. some runs completed before a timeout),
-    // write them to disk before re-throwing so CI artifacts capture what we have.
-    const partialResults = error.cause?.partialResults;
-    if (partialResults) {
-      try {
-        const outputPath = await recordTestOutput({
-          results: partialResults,
-          testFilename,
-          saveResponses
-        });
-        console.log(`\nPartial results recorded: ${outputPath}`);
-      } catch {
-        // Best-effort — don't mask the original error
+      // If the error carries partial results, write them before continuing.
+      const partialResults = error.cause?.partialResults;
+      if (partialResults) {
+        try {
+          const outputPath = await recordTestOutput({
+            results: partialResults,
+            testFilename: basename(filePath),
+            saveResponses
+          });
+          console.log(`\nPartial results recorded: ${outputPath}`);
+          outputPaths.push(outputPath);
+        } catch {
+          // Best-effort — don't mask the original error
+        }
       }
+      errors.push({ filePath, error });
     }
+  }
 
-    // error-causes wraps structured errors as { cause: { name, code, ... } }.
-    // Presence of cause.name is the stable public contract of the library — only
-    // changes if error-causes itself changes its API. Re-throw to avoid double-wrapping.
-    if (error.cause?.name) {
-      throw error;
-    }
+  if (errors.length > 0) {
+    const messages = errors.map(({ filePath, error }) => {
+      const msg = error.cause?.message || error.message;
+      return `  ${basename(filePath)}: ${msg}`;
+    }).join('\n');
 
     throw createError({
       ...AITestError,
-      message: `Failed to run AI tests: ${error.message}`,
-      cause: error
+      message: `${errors.length}/${filePaths.length} test file(s) failed:\n${messages}`,
+      outputPaths
     });
   }
+
+  return outputPaths;
 };

--- a/source/ai-command.test.js
+++ b/source/ai-command.test.js
@@ -1,11 +1,14 @@
 import { describe, test, vi, beforeEach, onTestFinished } from 'vitest';
 import { assert } from './vitest.js';
 import { Try } from './riteway.js';
-import { parseAIArgs, formatAssertionReport, runAICommand } from './ai-command.js';
+import { parseAIArgs, formatAssertionReport, runAICommand, resolveAITestFiles } from './ai-command.js';
 import { runAITests, verifyAgentAuthentication } from './ai-runner.js';
 import { resolveAgentConfig } from './agent-config.js';
 import { recordTestOutput } from './test-output.js';
 
+vi.mock('glob', () => ({
+  globSync: vi.fn((pattern) => [pattern])
+}));
 vi.mock('./ai-runner.js', () => ({
   runAITests: vi.fn(),
   verifyAgentAuthentication: vi.fn()
@@ -26,7 +29,7 @@ describe('parseAIArgs()', () => {
       should: 'apply default runs, threshold, timeout, agent, color, and concurrency',
       actual: result,
       expected: {
-        filePath: 'test.sudo',
+        patterns: ['test.sudo'],
         runs: 4,
         threshold: 75,
         timeout: 300000,
@@ -101,17 +104,28 @@ describe('parseAIArgs()', () => {
       given: 'multiple custom flags',
       should: 'parse all custom values correctly',
       actual: {
-        filePath: result.filePath,
+        patterns: result.patterns,
         runs: result.runs,
         threshold: result.threshold,
         agent: result.agent
       },
       expected: {
-        filePath: 'test.sudo',
+        patterns: ['test.sudo'],
         runs: 5,
         threshold: 60,
         agent: 'cursor'
       }
+    });
+  });
+
+  test('parses multiple file patterns as positional arguments', () => {
+    const result = parseAIArgs(['tests/*.sudo', 'evals/**/*.sudo']);
+
+    assert({
+      given: 'multiple positional arguments',
+      should: 'collect all patterns',
+      actual: result.patterns,
+      expected: ['tests/*.sudo', 'evals/**/*.sudo']
     });
   });
 
@@ -142,7 +156,7 @@ describe('parseAIArgs()', () => {
     assert({
       given: 'no file path argument',
       should: 'mention file path in error message',
-      actual: /filepath|file path/i.test(error?.cause?.message),
+      actual: /file path|pattern/i.test(error?.cause?.message),
       expected: true
     });
   });
@@ -403,11 +417,11 @@ describe('formatAssertionReport()', () => {
 });
 
 describe('runAICommand()', () => {
-  test('throws ValidationError when filePath is undefined', async () => {
-    const error = await Try(runAICommand, { filePath: undefined, runs: 4, threshold: 75, cwd: process.cwd() });
+  test('throws ValidationError when patterns is empty', async () => {
+    const error = await Try(runAICommand, { patterns: [], runs: 4, threshold: 75, cwd: process.cwd() });
 
     assert({
-      given: 'undefined filePath',
+      given: 'empty patterns array',
       should: 'throw ValidationError with missing file path message',
       actual: error?.cause,
       expected: {
@@ -418,27 +432,74 @@ describe('runAICommand()', () => {
     });
   });
 
-  test('throws SecurityError for path traversal attempt', async () => {
+  test('throws AITestError wrapping SecurityError for path traversal attempt', async () => {
+    vi.mocked(resolveAgentConfig).mockResolvedValue({ command: 'claude', args: [] });
+    vi.mocked(verifyAgentAuthentication).mockResolvedValue({ success: true });
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    onTestFinished(() => consoleSpy.mockRestore());
+
     const cwd = process.cwd();
     const error = await Try(runAICommand, {
-      filePath: '../../../etc/passwd',
+      patterns: ['../../../etc/passwd'],
       runs: 4,
       threshold: 75,
+      timeout: 300000,
       agent: 'claude',
+      concurrency: 4,
+      color: false,
+      saveResponses: false,
       cwd
     });
 
     assert({
       given: 'path traversal attempt',
-      should: 'throw SecurityError with path traversal details',
-      actual: error?.cause,
-      expected: {
-        name: 'SecurityError',
-        code: 'PATH_TRAVERSAL',
-        message: 'File path escapes base directory',
-        filePath: '../../../etc/passwd',
-        baseDir: cwd
-      }
+      should: 'throw AITestError with aggregate message containing security detail',
+      actual: error?.cause?.name,
+      expected: 'AITestError'
+    });
+
+    assert({
+      given: 'path traversal attempt',
+      should: 'include path traversal message in aggregate',
+      actual: error?.cause?.message?.includes('File path escapes base directory'),
+      expected: true
+    });
+  });
+});
+
+describe('resolveAITestFiles()', () => {
+  test('throws ValidationError when no files match', async () => {
+    const { globSync } = await import('glob');
+    vi.mocked(globSync).mockReturnValueOnce([]);
+
+    const error = Try(resolveAITestFiles, ['nonexistent/**/*.sudo']);
+
+    assert({
+      given: 'a pattern matching no files',
+      should: 'throw ValidationError',
+      actual: error?.cause?.name,
+      expected: 'ValidationError'
+    });
+
+    assert({
+      given: 'a pattern matching no files',
+      should: 'include the pattern in the error message',
+      actual: error?.cause?.message,
+      expected: 'No test files found matching: nonexistent/**/*.sudo'
+    });
+  });
+
+  test('returns expanded file paths from glob patterns', async () => {
+    const { globSync } = await import('glob');
+    vi.mocked(globSync).mockReturnValueOnce(['tests/a.sudo', 'tests/b.sudo']);
+
+    const result = resolveAITestFiles(['tests/*.sudo']);
+
+    assert({
+      given: 'a glob pattern matching two files',
+      should: 'return both file paths',
+      actual: result,
+      expected: ['tests/a.sudo', 'tests/b.sudo']
     });
   });
 });
@@ -450,7 +511,7 @@ describe('runAICommand() orchestration', () => {
     passed: true,
     assertions: [{ requirement: 'Given a test, should pass', passed: true, passCount: 4, totalRuns: 4 }]
   };
-  const args = { filePath: './test.sudo', runs: 4, threshold: 75, timeout: 300000, agent: 'claude', color: false, concurrency: 4, cwd: process.cwd() };
+  const args = { patterns: ['./test.sudo'], runs: 4, threshold: 75, timeout: 300000, agent: 'claude', color: false, concurrency: 4, cwd: process.cwd() };
 
   beforeEach(() => {
     vi.mocked(resolveAgentConfig).mockResolvedValue(agentConfig);
@@ -459,7 +520,7 @@ describe('runAICommand() orchestration', () => {
     vi.mocked(recordTestOutput).mockResolvedValue(outputPath);
   });
 
-  test('returns output path when tests pass', async () => {
+  test('returns output paths when tests pass', async () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     onTestFinished(() => consoleSpy.mockRestore());
 
@@ -467,9 +528,9 @@ describe('runAICommand() orchestration', () => {
 
     assert({
       given: 'valid test file and authenticated agent with passing results',
-      should: 'return path to TAP output file',
+      should: 'return array of paths to TAP output files',
       actual: result,
-      expected: outputPath
+      expected: [outputPath]
     });
   });
 
@@ -529,15 +590,16 @@ describe('runAICommand() orchestration', () => {
 
     assert({
       given: 'test suite with pass rate below threshold',
-      should: 'throw AITestError with suite failure message',
-      actual: error?.cause,
-      expected: {
-        name: 'AITestError',
-        code: 'AI_TEST_ERROR',
-        message: 'Test suite failed: 0/1 assertions passed (0%)',
-        passRate: 0,
-        threshold: 75
-      }
+      should: 'throw AITestError with aggregate failure message',
+      actual: error?.cause?.name,
+      expected: 'AITestError'
+    });
+
+    assert({
+      given: 'test suite with pass rate below threshold',
+      should: 'report 1/1 file(s) failed',
+      actual: error?.cause?.message?.includes('1/1 test file(s) failed'),
+      expected: true
     });
   });
 
@@ -560,7 +622,7 @@ describe('runAICommand() orchestration', () => {
     });
   });
 
-  test('throws OutputError when recordTestOutput fails', async () => {
+  test('throws AITestError wrapping OutputError when recordTestOutput fails', async () => {
     vi.mocked(recordTestOutput).mockRejectedValue(new Error('disk full'));
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     onTestFinished(() => consoleSpy.mockRestore());
@@ -569,14 +631,16 @@ describe('runAICommand() orchestration', () => {
 
     assert({
       given: 'output recording failure',
-      should: 'throw OutputError wrapping the disk error',
-      actual: error?.cause,
-      expected: {
-        name: 'OutputError',
-        code: 'OUTPUT_ERROR',
-        message: 'Failed to record test output: disk full',
-        cause: new Error('disk full')
-      }
+      should: 'throw AITestError with aggregate message',
+      actual: error?.cause?.name,
+      expected: 'AITestError'
+    });
+
+    assert({
+      given: 'output recording failure',
+      should: 'include disk error message in aggregate',
+      actual: error?.cause?.message?.includes('Failed to record test output: disk full'),
+      expected: true
     });
   });
 
@@ -596,9 +660,9 @@ describe('runAICommand() orchestration', () => {
 
     assert({
       given: 'runAITests returns zero assertions',
-      should: 'include (0%) in the AITestError message',
-      actual: error?.cause?.message,
-      expected: 'Test suite failed: 0/0 assertions passed (0%)'
+      should: 'include (0%) in the per-file error detail',
+      actual: error?.cause?.message?.includes('(0%)'),
+      expected: true
     });
   });
 
@@ -683,14 +747,110 @@ describe('runAICommand() orchestration', () => {
 
     assert({
       given: 'unexpected error without a structured cause',
-      should: 'wrap in AITestError preserving the original error',
-      actual: error?.cause,
-      expected: {
-        name: 'AITestError',
-        code: 'AI_TEST_ERROR',
-        message: 'Failed to run AI tests: connection refused',
-        cause: new Error('connection refused')
-      }
+      should: 'wrap in AITestError with aggregate failure message',
+      actual: error?.cause?.name,
+      expected: 'AITestError'
+    });
+
+    assert({
+      given: 'unexpected error without a structured cause',
+      should: 'include the original error message in the aggregate',
+      actual: error?.cause?.message?.includes('connection refused'),
+      expected: true
+    });
+  });
+
+  test('runs all files and returns all output paths when multiple files pass', async () => {
+    const { globSync } = await import('glob');
+    vi.mocked(globSync).mockReturnValueOnce(['./a.sudo', './b.sudo']);
+    vi.mocked(recordTestOutput)
+      .mockResolvedValueOnce('/ai-evals/a.tap.md')
+      .mockResolvedValueOnce('/ai-evals/b.tap.md');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    onTestFinished(() => consoleSpy.mockRestore());
+
+    const result = await runAICommand(args);
+
+    assert({
+      given: 'two passing test files',
+      should: 'return output paths for both files',
+      actual: result,
+      expected: ['/ai-evals/a.tap.md', '/ai-evals/b.tap.md']
+    });
+  });
+
+  test('continues running remaining files when one fails', async () => {
+    const { globSync } = await import('glob');
+    vi.mocked(globSync).mockReturnValueOnce(['./a.sudo', './b.sudo']);
+    vi.mocked(runAITests).mockReset();
+    vi.mocked(runAITests)
+      .mockResolvedValueOnce({
+        passed: false,
+        assertions: [{ requirement: 'test a', passed: false, passCount: 0, totalRuns: 4 }]
+      })
+      .mockResolvedValueOnce(passedResults);
+    vi.mocked(recordTestOutput)
+      .mockResolvedValueOnce('/ai-evals/a.tap.md')
+      .mockResolvedValueOnce('/ai-evals/b.tap.md');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    onTestFinished(() => consoleSpy.mockRestore());
+
+    const error = await Try(runAICommand, args);
+
+    assert({
+      given: 'first file fails and second file passes',
+      should: 'still run the second file',
+      actual: vi.mocked(runAITests).mock.calls.length,
+      expected: 2
+    });
+
+    assert({
+      given: 'first file fails and second file passes',
+      should: 'report 1/2 file(s) failed',
+      actual: error?.cause?.message?.includes('1/2 test file(s) failed'),
+      expected: true
+    });
+
+    assert({
+      given: 'first file fails and second file passes',
+      should: 'include the passing file output in outputPaths',
+      actual: error?.cause?.outputPaths,
+      expected: ['/ai-evals/b.tap.md']
+    });
+  });
+
+  test('uses correct filename for partial results per file', async () => {
+    const { globSync } = await import('glob');
+    vi.mocked(globSync).mockReturnValueOnce(['./first.sudo', './second.sudo']);
+    const partialResults = {
+      passed: false,
+      assertions: [{ requirement: 'test', passed: true, passCount: 1, totalRuns: 1 }],
+      responses: ['partial']
+    };
+    const timeoutError = new Error('outer');
+    timeoutError.cause = {
+      name: 'TimeoutError',
+      code: 'AGENT_TIMEOUT',
+      message: 'Agent timed out after 300000ms',
+      partialResults
+    };
+    vi.mocked(runAITests)
+      .mockResolvedValueOnce(passedResults)
+      .mockRejectedValueOnce(timeoutError);
+    vi.mocked(recordTestOutput).mockClear();
+    vi.mocked(recordTestOutput)
+      .mockResolvedValueOnce('/ai-evals/first.tap.md')
+      .mockResolvedValueOnce('/ai-evals/second-partial.tap.md');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    onTestFinished(() => consoleSpy.mockRestore());
+
+    await Try(runAICommand, { ...args, saveResponses: true });
+
+    assert({
+      given: 'second file times out with partial results',
+      should: 'record partial results under the second file name, not the first',
+      actual: vi.mocked(recordTestOutput).mock.calls[1]?.[0]?.testFilename,
+      expected: 'second.sudo'
     });
   });
 });


### PR DESCRIPTION
## Summary
- `riteway ai` now accepts glob patterns and multiple file arguments, not just a single file path
- e.g. `riteway ai 'evals/**/*.sudo'` or `riteway ai a.sudo b.sudo`
- Uses the same `globSync` from `glob` that the regular test runner already uses
- Authenticates the agent once, then runs each resolved file sequentially
- Errors with a clear message if no files match the pattern(s)

## Test plan
- [x] All 232 unit tests pass
- [x] All 26 CLI integration tests pass
- [ ] Manual test with glob pattern against real `.sudo` files