### PR TITLE
fix(ai): isolate cursor agent config dirs for parallel execution

### DIFF
--- a/source/agent-config.js
+++ b/source/agent-config.js
@@ -21,7 +21,9 @@ const agentConfigs = {
   cursor: {
     command: 'agent',
     args: ['--print', '--output-format', 'json', '--trust'],
-    outputFormat: 'json'
+    outputFormat: 'json',
+    isolateConfigEnv: 'CURSOR_CONFIG_DIR',
+    isolateConfigPrefix: 'riteway-cursor-'
   }
 };
 
@@ -47,7 +49,9 @@ export const getAgentConfig = (agentName = 'claude') => {
 const agentConfigFileSchema = z.object({
   command: z.string().min(1, { error: 'command is required' }),
   args: z.array(z.string()).default([]),
-  outputFormat: z.enum(['json', 'ndjson']).default('json')
+  outputFormat: z.enum(['json', 'ndjson']).default('json'),
+  isolateConfigEnv: z.string().min(1).optional(),
+  isolateConfigPrefix: z.string().min(1).optional()
 });
 
 // Throws AgentConfigReadError on any read failure, including ENOENT.

--- a/source/agent-config.test.js
+++ b/source/agent-config.test.js
@@ -40,7 +40,7 @@ describe('getAgentConfig()', () => {
       given: 'agent name "cursor"',
       should: 'return correct agent configuration with json outputFormat',
       actual: config,
-      expected: { command: 'agent', args: ['--print', '--output-format', 'json', '--trust'], outputFormat: 'json' }
+      expected: { command: 'agent', args: ['--print', '--output-format', 'json', '--trust'], outputFormat: 'json', isolateConfigEnv: 'CURSOR_CONFIG_DIR', isolateConfigPrefix: 'riteway-cursor-' }
     });
   });
 

--- a/source/execute-agent.js
+++ b/source/execute-agent.js
@@ -1,7 +1,25 @@
 import { spawn } from 'child_process';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createId } from '@paralleldrive/cuid2';
 import { createError } from 'error-causes';
 import { ParseError, TimeoutError, AgentProcessError } from './ai-errors.js';
 import { unwrapEnvelope, unwrapAgentResult, parseOpenCodeNDJSON } from './agent-parser.js';
+
+// Some CLIs (e.g. Cursor) race on a shared config tempfile during concurrent
+// writes. When isolateConfigEnv is set, each spawn gets a unique config dir
+// via cuid2. The CLI creates the directory on first write.
+const buildSpawnOptions = (agentConfig) => {
+  const { isolateConfigEnv, isolateConfigPrefix = '' } = agentConfig;
+  if (!isolateConfigEnv) return undefined;
+
+  return {
+    env: {
+      ...process.env,
+      [isolateConfigEnv]: join(tmpdir(), `${isolateConfigPrefix}${createId()}`)
+    }
+  };
+};
 
 const outputFormatParsers = {
   json: (stdout) => stdout,
@@ -38,7 +56,7 @@ const spawnProcess = ({ agentConfig, prompt }) => {
   const partialOutput = { stdout: '' };
 
   try {
-    const proc = spawn(command, allArgs);
+    const proc = spawn(command, allArgs, buildSpawnOptions(agentConfig));
     proc.stdin.end();
 
     return {
@@ -161,6 +179,8 @@ const runAgentProcess = async ({ agentConfig, prompt, timeout }) => {
  * @param {string} options.agentConfig.command - Command to execute
  * @param {Array<string>} [options.agentConfig.args=[]] - Command arguments
  * @param {'json'|'ndjson'} [options.agentConfig.outputFormat='json'] - Output format for parsing
+ * @param {string} [options.agentConfig.isolateConfigEnv] - Env var for per-spawn config dir isolation
+ * @param {string} [options.agentConfig.isolateConfigPrefix] - Prefix for the isolated temp dir name
  * @param {string} options.prompt - Prompt to send to the agent
  * @param {number} [options.timeout=300000] - Timeout in ms (default: 5 minutes)
  * @param {boolean} [options.rawOutput=false] - Return raw stdout string without JSON parsing

--- a/source/execute-agent.test.js
+++ b/source/execute-agent.test.js
@@ -53,6 +53,14 @@ const agentConfig = {
   args: ['-p', '--output-format', 'json', '--no-session-persistence']
 };
 
+const cursorAgentConfig = {
+  command: 'agent',
+  args: ['--print', '--output-format', 'json'],
+  outputFormat: 'json',
+  isolateConfigEnv: 'CURSOR_CONFIG_DIR',
+  isolateConfigPrefix: 'riteway-cursor-'
+};
+
 describe('executeAgent()', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -260,11 +268,79 @@ describe('executeAgent()', () => {
       prompt: 'my prompt'
     });
 
+    const [command, args] = spawn.mock.calls[0];
+
     assert({
       given: 'valid agentConfig with command and args',
       should: 'spawn process with command and args including prompt appended',
-      actual: spawn.mock.calls[0],
+      actual: [command, args],
       expected: ['claude', ['-p', '--output-format', 'json', '--no-session-persistence', 'my prompt']]
+    });
+  });
+
+  test('passes a unique CURSOR_CONFIG_DIR env to each cursor agent spawn', async () => {
+    spawn.mockImplementation(() => createMockProcess({ stdout: '{"ok":true}' }));
+
+    await executeAgent({ agentConfig: cursorAgentConfig, prompt: 'prompt 1' });
+    await executeAgent({ agentConfig: cursorAgentConfig, prompt: 'prompt 2' });
+
+    const dir1 = spawn.mock.calls[0][2]?.env?.CURSOR_CONFIG_DIR;
+    const dir2 = spawn.mock.calls[1][2]?.env?.CURSOR_CONFIG_DIR;
+
+    assert({
+      given: 'two sequential cursor agent calls',
+      should: 'pass a CURSOR_CONFIG_DIR string to the first spawn',
+      actual: typeof dir1,
+      expected: 'string'
+    });
+
+    assert({
+      given: 'two sequential cursor agent calls',
+      should: 'pass a CURSOR_CONFIG_DIR string to the second spawn',
+      actual: typeof dir2,
+      expected: 'string'
+    });
+
+    assert({
+      given: 'two sequential cursor agent calls',
+      should: 'use different CURSOR_CONFIG_DIR values for each spawn',
+      actual: dir1 !== dir2,
+      expected: true
+    });
+  });
+
+  test('concurrent cursor agent spawns receive unique CURSOR_CONFIG_DIR values', async () => {
+    spawn.mockImplementation(() => createMockProcess({ stdout: '{"ok":true}' }));
+
+    await Promise.all([
+      executeAgent({ agentConfig: cursorAgentConfig, prompt: 'concurrent 1' }),
+      executeAgent({ agentConfig: cursorAgentConfig, prompt: 'concurrent 2' }),
+      executeAgent({ agentConfig: cursorAgentConfig, prompt: 'concurrent 3' })
+    ]);
+
+    const dirs = spawn.mock.calls.map(call => call[2]?.env?.CURSOR_CONFIG_DIR);
+    const uniqueDirs = new Set(dirs);
+
+    assert({
+      given: 'three concurrent cursor agent calls',
+      should: 'assign a unique CURSOR_CONFIG_DIR to each',
+      actual: uniqueDirs.size,
+      expected: 3
+    });
+  });
+
+  test('does not set CURSOR_CONFIG_DIR for non-cursor agents', async () => {
+    spawn.mockReturnValue(createMockProcess({ stdout: '{"ok":true}' }));
+
+    await executeAgent({ agentConfig, prompt: 'test prompt' });
+
+    const options = spawn.mock.calls[0][2];
+
+    assert({
+      given: 'a claude agent (non-cursor)',
+      should: 'not pass spawn options',
+      actual: options,
+      expected: undefined
     });
   });
 });


### PR DESCRIPTION
## Summary

- When multiple Cursor CLI agents run concurrently (result agents + judge agents), they all race on `~/.cursor/cli-config.json.tmp` during atomic config writes, causing `ENOENT` crashes on `rename`
- Fix: each spawned cursor agent process gets a unique `CURSOR_CONFIG_DIR` (using cuid2) pointing to an isolated temp directory, eliminating the race
- Only applies to cursor agents — claude and opencode agents are unaffected

## Root cause

The Cursor CLI writes config atomically via `cli-config.json.tmp` → `cli-config.json` rename. With concurrent processes, one process completes the rename while another tries to rename the same `.tmp` file that no longer exists. This is the same class of bug reported in [Gemini CLI](https://github.com/google-gemini/gemini-cli/issues/22583) and [Claude Code](https://github.com/anthropics/claude-code/issues/28842).

## Test plan

- [x] New test: each cursor agent spawn receives a unique `CURSOR_CONFIG_DIR`
- [x] New test: concurrent cursor spawns all get different `CURSOR_CONFIG_DIR` values  
- [x] New test: non-cursor agents (claude) do NOT get `CURSOR_CONFIG_DIR` set
- [x] All 238 existing tests pass with no regressions