### PR TITLE
fix(cursor agent errors): Add '--trust' argument to agent command

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The generated file is a keyed registry. Add a custom agent entry and use it with
 {
   "claude":   { "command": "claude",   "args": ["-p", "--output-format", "json", "--no-session-persistence"], "outputFormat": "json"  },
   "opencode": { "command": "opencode", "args": ["run", "--format", "json"],                                   "outputFormat": "ndjson" },
-  "cursor":   { "command": "agent",    "args": ["--print", "--output-format", "json"],                        "outputFormat": "json"  },
+  "cursor":   { "command": "agent",    "args": ["--print", "--output-format", "json", "--trust"],             "outputFormat": "json"  },
   "my-agent": { "command": "my-tool",  "args": ["--json"],                                                    "outputFormat": "json"  }
 }
 ```

--- a/source/agent-config.js
+++ b/source/agent-config.js
@@ -20,7 +20,7 @@ const agentConfigs = {
   },
   cursor: {
     command: 'agent',
-    args: ['--print', '--output-format', 'json'],
+    args: ['--print', '--output-format', 'json', '--trust'],
     outputFormat: 'json'
   }
 };

--- a/source/agent-config.test.js
+++ b/source/agent-config.test.js
@@ -40,7 +40,7 @@ describe('getAgentConfig()', () => {
       given: 'agent name "cursor"',
       should: 'return correct agent configuration with json outputFormat',
       actual: config,
-      expected: { command: 'agent', args: ['--print', '--output-format', 'json'], outputFormat: 'json' }
+      expected: { command: 'agent', args: ['--print', '--output-format', 'json', '--trust'], outputFormat: 'json' }
     });
   });
 


### PR DESCRIPTION
Cursor CLI exits with error because it needs `--trust` in non-interactive mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates a single CLI invocation flag for the `cursor` agent and adjusts docs/tests accordingly, with no broader logic or data-handling changes.
> 
> **Overview**
> Fixes non-interactive `cursor` runs by adding the `--trust` flag to the built-in `cursor` agent command arguments.
> 
> Updates the README example registry and the `getAgentConfig('cursor')` test expectation to match the new default args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea7ff5a25477cf756bc1c5854f8f3cc998316041. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->